### PR TITLE
Fix payment method text position

### DIFF
--- a/hitpay-payment-gateway/hitpay-payment-gateway.php
+++ b/hitpay-payment-gateway/hitpay-payment-gateway.php
@@ -98,8 +98,8 @@ function woocommerce_hitpay_init() {
                 
                 if (!empty($payment_method)) {
             ?>
-                    <p style="padding: 10px; font-size: 16px; color: blue; position: relative; top: 10px;">
-                    <?php echo __('HitPay Payment Method:', $this->domain) ?> <span style="color: blue;"><?php echo ucfirst($payment_method)?></span>
+                    <p class="form-field form-field-wide wc-hitpay-status" style="padding: 10px; font-size: 16px; color: blue; top: 10px;">
+                        <?php echo __('HitPay Payment Method:', $this->domain) ?> <span style="color: blue;"><?php echo ucwords(str_replace("_", " ", $payment_method)) ?></span>
                     </p>
             <?php
                 }


### PR DESCRIPTION
Fix the payment text blocking the "customer" and "status" dropdowns within the order details page.
Proper capitalisation for payment method (eg. Paynow_online will now show as Paynow Online)