### PR TITLE
= 4.1.8 = Added Test Connection button

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,10 +5,10 @@ Contributors: HitPay
 Tags: hitpay, payment gateway, woocommerce, QR code
 Requires at least: 4.0
 Tested up to: 6.7.2
-Stable tag: 4.1.7
+Stable tag: 4.1.8
 Requires PHP: 5.5
 WC requires at least: 2.4
-WC tested up to: 9.7.1
+WC tested up to: 9.8.1
 License: MIT
 
 HitPay Payment Gateway Plugin allows HitPay merchants to accept PayNow QR, Cards, Apple Pay, Google Pay, WeChatPay, AliPay and GrabPay Payments.
@@ -117,14 +117,21 @@ The easiest and fastest way is via our live chat on our [website](https://www.hi
 
 == Changelog ==
 
+= 4.1.8 =
+* Apr 11, 2025
+* Added Test Connection button
+* Applied Plugin Check (PCP) Recemmendations for the latest version 1.4.0
+* Plugin tested on WooCommerce 9.8.1
+* Plugin tested on WordPress 6.7.2
+
 = 4.1.7 =
-* Jan 15, 2025
+* Mar 23, 2025 and Jan 15, 2025
 * Applied various security fixes
 * Applied more Plugin Check Recemmendations
-* Fixed payment status page stuck when extra <p> tag wrapped around scripts with third party plugins in use like Elementor
+* Fixed payment status page stuck when extra P tag wrapped around scripts with third party plugins in use like Elementor
 * Now upto 30 POS terminals can be added
-* Plugin tested on WooCommerce 9.5.2
-* Plugin tested on WordPress 6.7.1
+* Plugin tested on WooCommerce 9.7.1
+* Plugin tested on WordPress 6.7.2
 
 = 4.1.6 =
 * Jul 23, 2024

--- a/hitpay-payment-gateway/composer.json
+++ b/hitpay-payment-gateway/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "softbuild/hitpay-sdk",
+    "type": "php",
+    "require": {
+        "php": ">=5.6"
+    },
+    "authors": [
+        {
+            "name": "HitPay Payment Solutions Pte Ltd",
+            "email": "support@hitpay.zendesk.com"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "HitPay\\": "src/"
+        }
+    }
+}

--- a/hitpay-payment-gateway/hitpay-payment-gateway.php
+++ b/hitpay-payment-gateway/hitpay-payment-gateway.php
@@ -2,11 +2,11 @@
 /*
 Plugin Name: HitPay Payment Gateway for WooCommerce
 Description: HitPay Payment Gateway Plugin allows HitPay merchants to accept PayNow QR, Cards, Apple Pay, Google Pay, WeChatPay, AliPay and GrabPay Payments. You will need a HitPay account, contact support@hitpay.zendesk.com.
-Version: 4.1.7
+Version: 4.1.8
 Requires at least: 4.0
-Tested up to: 6.7.1
+Tested up to: 6.7.2
 WC requires at least: 2.4
-WC tested up to: 9.5.2
+WC tested up to: 9.8.1
 Requires PHP: 5.5
 Author: <a href="https://www.hitpayapp.com>HitPay Payment Solutions Pte Ltd</a>   
 Author URI: https://www.hitpayapp.com
@@ -17,7 +17,7 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly
 }
 
-define('HITPAY_VERSION', '4.1.6');
+define('HITPAY_VERSION', '4.1.8');
 define('HITPAY_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('HITPAY_PLUGIN_PATH', plugin_dir_path(__FILE__));
 

--- a/hitpay-payment-gateway/includes/blocks-checkout.php
+++ b/hitpay-payment-gateway/includes/blocks-checkout.php
@@ -110,7 +110,7 @@ final class WC_Hitpay_Blocks_Support extends AbstractPaymentMethodType {
     
     private function isPosEnabled() {
         $status = false;
-        if ($this->gateway->enable_pos) {
+        if ($this->gateway->enable_pos == 1) {
             $status = true;
         } 
         return $status;
@@ -118,7 +118,7 @@ final class WC_Hitpay_Blocks_Support extends AbstractPaymentMethodType {
 	
 	private function getPlaceOrderText() {
         $text = '';
-        if ($this->gateway->payment_button) {
+        if ($this->gateway->payment_button == 1) {
             $text = $this->gateway->place_order_text;
         } 
         return $text;

--- a/hitpay-payment-gateway/readme.txt
+++ b/hitpay-payment-gateway/readme.txt
@@ -3,10 +3,10 @@ Contributors: HitPay
 Tags: hitpay, payment gateway, woocommerce, QR code
 Requires at least: 4.0
 Tested up to: 6.7.2
-Stable tag: 4.1.7
+Stable tag: 4.1.8
 Requires PHP: 5.5
 WC requires at least: 2.4
-WC tested up to: 9.7.1
+WC tested up to: 9.8.1
 License: MIT
 
 HitPay Payment Gateway Plugin allows HitPay merchants to accept PayNow QR, Cards, Apple Pay, Google Pay, WeChatPay, AliPay and GrabPay Payments.
@@ -87,11 +87,20 @@ The easiest and fastest way is via our live chat on our [website](https://www.hi
 
 == Changelog ==
 
+= 4.1.8 =
+* Apr 11, 2025
+* Added Test Connection button
+* Fixed: Issue displayed the online payment select option when POS not enabled for the block checkout.
+* Applied various security fixes
+* Applied Plugin Check (PCP) Recemmendations for the latest version 1.4.0
+* Plugin tested on WooCommerce 9.8.1
+* Plugin tested on WordPress 6.7.2
+
 = 4.1.7 =
 * Mar 23, 2025 and Jan 15, 2025
 * Applied various security fixes
 * Applied more Plugin Check Recemmendations
-* Fixed payment status page stuck when extra <p> tag wrapped around scripts with third party plugins in use like Elementor
+* Fixed payment status page stuck when extra P tag wrapped around scripts with third party plugins in use like Elementor
 * Now upto 30 POS terminals can be added
 * Plugin tested on WooCommerce 9.7.1
 * Plugin tested on WordPress 6.7.2

--- a/hitpay-payment-gateway/vendor/softbuild/hitpay-sdk/src/Request.php
+++ b/hitpay-payment-gateway/vendor/softbuild/hitpay-sdk/src/Request.php
@@ -127,7 +127,7 @@ class Request
         } elseif ($httpCode != 200 && $httpCode != 201) {
             $message = isset($this->errors[$httpCode])
                 ? $this->errors[$httpCode]
-                : 'Error message does not exists.';
+                : $httpCode. ': Failed to connect to HitPay Gateway Server, please contact us with your site server IP address.';
             throw new \Exception($message, $httpCode);
         }
     }


### PR DESCRIPTION
= 4.1.8 =
* Apr 11, 2025
* Added Test Connection button
* Fixed: Issue displayed the online payment select option when POS not enabled for the block checkout.
* Applied various security fixes
* Applied Plugin Check (PCP) Recemmendations for the latest version 1.4.0
* Plugin tested on WooCommerce 9.8.1
* Plugin tested on WordPress 6.7.2